### PR TITLE
Fix undefined colortemperature durng device discovery and cache color…

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,8 +87,15 @@ SengledHubPlatform.prototype.deviceDiscovery = function() {
 				me.addAccessory(devices[i]);
 			} else {
 				existing.status = devices[i].status;
-                existing.brightness = devices[i].brightness;
-                existing.colorTemperature = devices[i].colorTemperature;
+                		existing.brightness = devices[i].brightness;
+                		existing.colorTemperature = devices[i].colorTemperature;
+				existing.colorMode = devices[i].colorMode;
+				existing.rgbColorR = devices[i].rgbColorR;
+				existing.rgbColorG = devices[i].rgbColorG;
+				existing.rgbColorB = devices[i].rgbColorB
+				existing.isOnline = devices[i].isOnline;
+				existing.signalQuality = devices[i].signalQuality;
+
 				if (me.debug) me.log("Skipping existing device", i);
 			}
 		}

--- a/lib/client.js
+++ b/lib/client.js
@@ -102,24 +102,27 @@ module.exports = class ElementHomeClient {
 		}
 		
 		return new Promise((fulfill, reject) => {
-			this.client.post('/room/getUserRoomsDetail.json', {})
+			this.client.post('/device/getDeviceDetails.json', {})
 				.then((response) => {
 					if (response.data.ret == 100) {
 						reject(response.data);
 					} else {
-						let roomList = response.data.roomList
-						let deviceList = _ArrayFlatMap(roomList, i => i.deviceList);
-						deviceList = deviceList.concat(response.data.deviceNoRoomList);
-						let devices = deviceList.map((device) => {
+						let deviceInfos = response.data.deviceInfos;
+						let lampInfos = _ArrayFlatMap(deviceInfos, i => i.lampInfos);
+						let devices = lampInfos.map((device) => {
 							var newDevice = {
 								id: device.deviceUuid,
-								name: device.deviceName,
-								status: device.onoff,
-								brightness: device.brightness,
-								colortemperature: device.colortemperature,
-								isOnline: device.isOnline,
-								signalQuality: device.signalQuality,
-								productCode: device.productCode
+								name: device.attributes.name,
+								status: device.attributes.onoff,
+								brightness: device.attributes.brightness,
+								colortemperature: device.attributes.colorTemperature,
+								isOnline: device.attributes.isOnline,
+								signalQuality: device.attributes.deviceRssi,
+								productCode: device.attributes.productCode,
+								colorMode: device.attributes.colorMode,
+								rgbColorR: device.attributes.rgbColorR,
+								rgbColorG: device.attributes.rgbColorG,
+								rgbColorB: device.attributes.rgbColorB
 							};
 							me.cache[newDevice.id] = newDevice;
 							me.lastCache = moment();


### PR DESCRIPTION
This change modifies device retrieval to fix missing data for brightness, colortemperature, and signalstrength members.  It also adds additional data, such as colormode and rgbColor* for RGBW bulbs like the E12-N1E. 
Using getUserRoomsDetail.json returns device objects that did not have brightness and colortemperature fields:

[11/13/2021, 5:16:18 PM] [SengledHub] {
  deviceUuid: '<ommitted>',
  deviceName: 'Rear Left',
  isOnline: 1,
  onOff: 0,
  productCode: 'E12-N1E'
}

Perhaps the API changed at some point, but note I've only tested with E12-N1E.  getDeviceDetails.json returns the expected info:

[11/13/2021, 6:41:40 PM] [SengledHub] {
  deviceUuid: '<ommitted>',
  deviceClass: 1,
  supportAttributes: '0,1,2,3,4,12,13',
  attributes: {
    deviceRssi: '0',
    rgbColorR: '255',
    activeTime: '2021-11-08 21:57:51',
    colorMode: '1',
    rgbColorG: '224',
    isOnline: '1',
    version: '30',
    typeCode: 'E12-N1E',
    colorTemperature: '66',
    effectStatus: '0',
    productCode: 'E12-N1E',
    brightness: '64',
    rgbColorB: '196',
    name: 'Rear Right',
    onCount: '23',
    onoff: '1'
  }
}

