### PR TITLE
Fix context state On upgrade Issue. Add login/timeout config. Fix device rename and missing.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -38,6 +38,20 @@
                 "type": "boolean",
                 "default": false,
                 "description": "This will enable information from the plugin."
+            },
+            "Timeout": {
+                "title": "Timeout",
+                "type": "integer",
+                "default": 4000,
+                "minimum": 2000,
+                "maximum": 30000,
+                "description": "The timeout in milliseconds to use for calls to the Sengled Web API. High values may result in other errors."
+            },
+            "AlternateLoginApi": {
+                "title": "AlternateLoginApi",
+                "type": "boolean",
+                "default": false,
+                "description": "Uses an alternative login API if for some reason logins fail even with increased timeout."
             }
         }
     }

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ SengledHubPlatform.prototype.deviceDiscovery = function() {
 		}
 
 		if (me.debug) me.log("Discovery complete");
-		if (me.debug) me.log(JSON.stringify(me.accessories, null, 4));
+		// if (me.debug) me.log(JSON.stringify(me.accessories, null, 4));
 	}).catch((err) => {
 		this.log("Failed deviceDiscovery: ");
 		this.log(me.debug ? err : err.message);

--- a/index.js
+++ b/index.js
@@ -136,7 +136,6 @@ SengledHubPlatform.prototype.deviceDiscovery = function() {
 	}).catch((err) => {
 		this.log("Failed deviceDiscovery: ");
 		this.log(me.debug ? err : err.message);
->>>>>>> Logins are currently timing out via the existing method, but this seems to work with a higher timout.
 	});
 };
 

--- a/index.js
+++ b/index.js
@@ -125,7 +125,11 @@ SengledHubPlatform.prototype.deviceDiscovery = function() {
 		}
 
 		if (me.debug) me.log("Discovery complete");
-		// if (me.debug) me.log(JSON.stringify(me.accessories, null, 4));
+		if (me.debug) me.log(JSON.stringify(me.accessories, null, 4));
+	}).catch((err) => {
+		this.log("Failed deviceDiscovery: ");
+		this.log(me.debug ? err : err.message);
+>>>>>>> Logins are currently timing out via the existing method, but this seems to work with a higher timout.
 	});
 };
 
@@ -330,26 +334,28 @@ SengledLightAccessory.prototype.getPowerState = function(callback) {
 	let me = this;
 	if (this.debug) this.log("Getting device PowerState: " + this.getName() + " status");
 
-	return this.client.login(this.username, this.password).then(() => {
-		return this.client.getDevices();
-	}).then(devices => {
-		return devices.find((device) => {
-			return device.id.includes(this.getId());
-		});
-	}).then((device) => {
-		if (typeof device === 'undefined') {
-			if (this.debug) this.log("Removing undefined device", this.getName());
-			this.platform.removeAccessory(this.accessory);
-		} else {
-			if (this.debug) this.log("getPowerState complete: " + device.name + " " + this.getName() + " is " + device.status);
-			this.context.status = device.status;
-			callback(null, device.status);
-		}
-	}).catch((err) => {
-		this.log("Failed to get power state");
-		this.log(err.message);
-		callback(err);
-	});
+	callback(null, this.context.status);
+
+//	return this.client.login(this.username, this.password).then(() => {
+//		return this.client.getDevices();
+//	}).then(devices => {
+//		return devices.find((device) => {
+//			return device.id.includes(this.getId());
+//		});
+//	}).then((device) => {
+//		if (typeof device === 'undefined') {
+//			if (this.debug) this.log("Removing undefined device", this.getName());
+//			this.platform.removeAccessory(this.accessory);
+//		} else {
+//			if (this.debug) this.log("getPowerState complete: " + device.name + " " + this.getName() + " is " + device.status);
+//			this.context.status = device.status;
+//			callback(null, device.status);
+//		}
+//	}).catch((err) => {
+//		this.log("Failed to get power state");
+//		this.log(err.message);
+//		callback(err);
+//	});
 };
 
 SengledLightAccessory.prototype.setBrightness = function(brightness, callback) {

--- a/index.js
+++ b/index.js
@@ -335,27 +335,6 @@ SengledLightAccessory.prototype.getPowerState = function(callback) {
 	if (this.debug) this.log("Getting device PowerState: " + this.getName() + " status");
 
 	callback(null, this.context.status);
-
-//	return this.client.login(this.username, this.password).then(() => {
-//		return this.client.getDevices();
-//	}).then(devices => {
-//		return devices.find((device) => {
-//			return device.id.includes(this.getId());
-//		});
-//	}).then((device) => {
-//		if (typeof device === 'undefined') {
-//			if (this.debug) this.log("Removing undefined device", this.getName());
-//			this.platform.removeAccessory(this.accessory);
-//		} else {
-//			if (this.debug) this.log("getPowerState complete: " + device.name + " " + this.getName() + " is " + device.status);
-//			this.context.status = device.status;
-//			callback(null, device.status);
-//		}
-//	}).catch((err) => {
-//		this.log("Failed to get power state");
-//		this.log(err.message);
-//		callback(err);
-//	});
 };
 
 SengledLightAccessory.prototype.setBrightness = function(brightness, callback) {

--- a/index.js
+++ b/index.js
@@ -22,13 +22,15 @@ function SengledHubPlatform(log, config, api) {
 	this.info = config['info'] || true;
 	this.username = config['username'];
 	this.password = config['password'];
+	this.useAlternateLoginApi = config['AlternateLoginApi'];
+	this.timeout = config['Timeout'];
 
 	if (api) {
 		this.api = api;
 		this.api.on('didFinishLaunching', this.didFinishLaunching.bind(this));
 	}
 
-	this.client = new ElementHomeClient(log, this.debug, this.info);
+	this.client = new ElementHomeClient(this.useAlternateLoginApi, this.timeout, log, this.debug, this.info);
 }
 
 SengledHubPlatform.prototype.configureAccessory = function(accessory) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -108,7 +108,8 @@ login(username, password) {
 			if (me.debug || me.info) me.log("login via api");
 		}
 
-		// Return codes These are not currenlty being checked.  Only 0 and 1 have been verified to be correct.
+		// Return codes These are not currenlty being checked.  Only 0 and 1 have been verified to
+		// match these descriptions:
 		// -1 - Server error.
 		//  0 - Success
 		//  1 - "参数错误" - An argument is incorrect

--- a/lib/client.js
+++ b/lib/client.js
@@ -67,18 +67,20 @@ class Brightness  {
 
 class ElementHomeClient {
 
-  constructor(log, debug = false, info = false) {
+  constructor(useAlternateLoginApi, timeout, log, debug = false, info = false) {
+
+    this.useAlternateLoginApi = useAlternateLoginApi;
 
     this.client = axios.create({
-      timeout: 4000,
+      timeout: timeout,
       jar: cookieJar,
       withCredentials: true,
       responseType: 'json'
     });
     this.client.defaults.headers.post['Content-Type'] = 'application/json';
-    this.log = log
-	  this.debug = debug
-    this.info = info
+    this.log = log;
+    this.debug = debug;
+    this.info = info;
  		if (this.info) this.log("Starting Sengled Client...");
 	  this.log("Starting Sengled Client...");
     this.lastLogin = moment('2000-01-01')
@@ -108,32 +110,53 @@ login(username, password) {
 			if (me.debug || me.info) me.log("login via api");
 		}
 
-		// Return codes These are not currenlty being checked.  Only 0 and 1 have been verified to
-		// match these descriptions:
-		// -1 - Server error.
-		//  0 - Success
-		//  1 - "参数错误" - An argument is incorrect
-		//  2 - "用户名或密码错误" Incorrect password
-		//  3 - "用户名不存在: Incorrect username
+		if (!this.useAlternateLoginApi) {
 
-		this.client.post('https://ucenter.cloud.sengled.com/user/app/customer/v2/AuthenCross.json',
-		{
-			'uuid': this.uuid,
-			'user': username,
-			'pwd': password,
-			'osType': 'android',
-			'productCode': 'life',
-			'appCode': 'life'
-		}).then((response) => {
-			this.jsessionid = response.data.jsessionId;
-			this.lastLogin = moment();
-			this.loginResponse = response;
-			if (me.debug) me.log("logged in to Sengled");
-			fulfill(response);
-		}).catch(function (error) {
-			reject(error);
-		});
+			this.client.post('https://us-elements.cloud.sengled.com/zigbee/customer/login.json',
+			{
+				'uuid': this.uuid,
+				'user': username,
+				'pwd': password,
+				'os_type': 'android'
+			}).then((response) => {
+				this.jsessionid = response.data.jsessionId;
+				this.lastLogin = moment();
+				this.loginResponse = response;
+				if (me.debug) me.log("logged in to Sengled");
+				fulfill(response);
+			}).catch(function (error) {
+				reject(error);
+			});
+		}
+		else {
+			// Return codes These are not currenlty being checked.  Only 0 and 1 have been verified to
+			// match these descriptions:
+			// -1 - Server error.
+			//  0 - Success
+			//  1 - "参数错误" - An argument is incorrect
+			//  2 - "用户名或密码错误" Incorrect password
+			//  3 - "用户名不存在: Incorrect username
+
+			this.client.post('https://ucenter.cloud.sengled.com/user/app/customer/v2/AuthenCross.json',
+			{
+				'uuid': this.uuid,
+				'user': username,
+				'pwd': password,
+				'osType': 'android',
+				'productCode': 'life',
+				'appCode': 'life'
+			}).then((response) => {
+				this.jsessionid = response.data.jsessionId;
+				this.lastLogin = moment();
+				this.loginResponse = response;
+				if (me.debug) me.log("logged in to Sengled");
+				fulfill(response);
+			}).catch(function (error) {
+				reject(error);
+			});
+		}
 	});
+
 }
 
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -178,8 +178,8 @@ login(username, password) {
 					if (response.data.ret == 100) {
 						reject(response.data);
 					} else {
-						let deviceInfos = response.data.deviceInfos;
-						let lampInfos = _ArrayFlatMap(deviceInfos, i => i.lampInfos);
+						let deviceInfos = response.data.hasOwnProperty('deviceInfos') ? response.data.deviceInfos : [];
+						let lampInfos = _ArrayFlatMap(deviceInfos, i => i.hasOwnProperty('lampInfos') ? i.lampInfos : []);
 						let devices = lampInfos.map((device) => {
 
 						let attributes = device.attributes;

--- a/lib/client.js
+++ b/lib/client.js
@@ -70,7 +70,6 @@ class ElementHomeClient {
   constructor(log, debug = false, info = false) {
 
     this.client = axios.create({
-      baseURL: 'https://us-elements.cloud.sengled.com/zigbee/',
       timeout: 4000,
       jar: cookieJar,
       withCredentials: true,
@@ -89,43 +88,52 @@ class ElementHomeClient {
  		if (this.debug) this.log("set cache duration " + this.cacheDuration);
   }
 
-  login(username, password) {
+login(username, password) {
 	let me = this;
 	if (me.debug) me.log("login invoked " + username);
-  if (me.debug) me.log("login sessionid " + this.jsessionid);
-    // If token has been set in last 24 hours, don't log in again
-    // if (this.lastLogin.isAfter(moment().subtract(24, 'hours'))) {
-    //     return Promise.resolve();
-    // }
+ 	if (me.debug) me.log("login sessionid " + this.jsessionid);
+	// If token has been set in last 24 hours, don't log in again
+	// if (this.lastLogin.isAfter(moment().subtract(24, 'hours'))) {
+	//     return Promise.resolve();
+	// }
 
 
-  return new Promise((fulfill, reject) => {
-    if (this.jsessionid != null) {
-      this.log("Cookie found, skipping login request.");
-      if (me.debug) me.log("login via cookie");
-      fulfill(this.loginResponse);
-    } else {
-      if (me.debug || me.info) me.log("login via api"); }
-    this.client.post('/customer/login.json',
-    {
-      'uuid':this.uuid,
-      'user': username,
-      'pwd': password,
-      'os_type': 'android'
-    }).then((response) => {
-      this.jsessionid = response.data.jsessionid;
-      this.lastLogin = moment();
-      this.loginResponse = response;
-      if (me.debug) me.log("logged in to Sengled");
-      fulfill(response);
-    }).catch(function (error) {
-      reject(error);
-    });
+	return new Promise((fulfill, reject) => {
+		if (this.jsessionid != null) {
+			this.log("Cookie found, skipping login request.");
+			if (me.debug) me.log("login via cookie");
+			fulfill(this.loginResponse);
+		}
+		else {
+			if (me.debug || me.info) me.log("login via api");
+		}
 
-  });
+		// Return codes These are not currenlty being checked.  Only 0 and 1 have been verified to be correct.
+		// -1 - Server error.
+		//  0 - Success
+		//  1 - "参数错误" - An argument is incorrect
+		//  2 - "用户名或密码错误" Incorrect password
+		//  3 - "用户名不存在: Incorrect username
 
-
-  }
+		this.client.post('https://ucenter.cloud.sengled.com/user/app/customer/v2/AuthenCross.json',
+		{
+			'uuid': this.uuid,
+			'user': username,
+			'pwd': password,
+			'osType': 'android',
+			'productCode': 'life',
+			'appCode': 'life'
+		}).then((response) => {
+			this.jsessionid = response.data.jsessionId;
+			this.lastLogin = moment();
+			this.loginResponse = response;
+			if (me.debug) me.log("logged in to Sengled");
+			fulfill(response);
+		}).catch(function (error) {
+			reject(error);
+		});
+	});
+}
 
 
   getDevices() {
@@ -141,7 +149,7 @@ class ElementHomeClient {
 		}
 
 		return new Promise((fulfill, reject) => {
-			this.client.post('/device/getDeviceDetails.json', {})
+			this.client.post('https://us-elements.cloud.sengled.com/zigbee/device/getDeviceDetails.json', {})
 				.then((response) => {
 					if (response.data.ret == 100) {
 						reject(response.data);
@@ -216,6 +224,7 @@ class ElementHomeClient {
 							color: color
 						};
 
+
 						// Cache this device and set the last time the cache was updated.
 						me.cache[newDevice.id] = newDevice;
 						me.lastCache = moment();
@@ -233,7 +242,7 @@ class ElementHomeClient {
 	let me = this;
 	if (me.debug) me.log("userInfo invoked ");
     return new Promise((fulfill, reject) => {
-      this.client.post('/customer/getUserInfo.json', {})
+      this.client.post('https://us-elements.cloud.sengled.com/zigbee/customer/getUserInfo.json', {})
       .then((response) => {
         if (response.data.ret == 100) {
           reject(response.data);
@@ -250,7 +259,7 @@ class ElementHomeClient {
     let me = this;
     if (me.debug) me.log('onOff ' + deviceId + ' ' + onoff);
     return new Promise((fulfill, reject) => {
-      this.client.post('/device/deviceSetOnOff.json', {"onoff": onoff ? 1 : 0,"deviceUuid": deviceId})
+      this.client.post('https://us-elements.cloud.sengled.com/zigbee/device/deviceSetOnOff.json', {"onoff": onoff ? 1 : 0,"deviceUuid": deviceId})
       .then((response) => {
         if (response.data.ret == 100) {
           reject(response.data);
@@ -267,7 +276,7 @@ class ElementHomeClient {
   deviceSetBrightness(deviceId, brightness) {
     return new Promise((fulfill, reject) => {
         this.client
-            .post('/device/deviceSetBrightness.json', {
+            .post('https://us-elements.cloud.sengled.com/zigbee/device/deviceSetBrightness.json', {
                 brightness: brightness,
                 deviceUuid: deviceId
             })
@@ -288,7 +297,7 @@ class ElementHomeClient {
 deviceSetColorTemperature(deviceId, colorTemperature) {
     return new Promise((fulfill, reject) => {
         this.client
-            .post('/device/deviceSetColorTemperature.json', {
+            .post('https://us-elements.cloud.sengled.com/zigbee/device/deviceSetColorTemperature.json', {
                 colorTemperature: colorTemperature,
                 deviceUuid: deviceId
             })
@@ -309,7 +318,7 @@ deviceSetColorTemperature(deviceId, colorTemperature) {
 deviceSetRgbColor(deviceId, rgb) {
     return new Promise((fulfill, reject) => {
         this.client
-            .post('/device/deviceSetGroup.json', {
+            .post('https://us-elements.cloud.sengled.com/zigbee/device/deviceSetGroup.json', {
 		cmdId: 129,
 		deviceUuidList: [{ deviceUuid: deviceId}],
 		rgbColorR: rgb.r,

--- a/lib/color.js
+++ b/lib/color.js
@@ -1,3 +1,4 @@
+'use strict';
 
 class ColorConfigData {
 	constructor(maxColorTemperature, minColorTemperature) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-sengled-bulbs",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A unoffical Homebridge plugin for controlling sengled accessories.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This change defers creation of SengledLightAccessory instances until the didFinishLaunching callback, after context data has been updated from the Sengled client. This should resolve crashes on updates where context data is changed, but the homebridge cached accessory still has the old version.

A timeout and alternate login api option is added. The timeout appears as a slider in the homebridge plugin settings, and the alternate login URL shows up as a checkmark. Defaults are to keep the same behavior as before this change. The alternate login URL required removing the baseURL and updating all URLs to be full paths. The existing sengled login API stopped working for me during development of this change, so I needed to add this to keep the sengled api working for me.

While testing, discovered that the change that introduced the context data upgrade issue also regressed device rename handling, this change also fixes that. Some fixes for potential issues when Sengled API reports no devices. getDevices should always return a valid object. Simplified removal of accessories that are registered, but no longer reported by the sengled API.

Change SengledLightAccessory to use updateValue during initialization to update context data from Sengled API instead of invoking callbacks via getValue.

Rev'd the package.json.