### PR TITLE
Fix Characteristic 'On': SET handler returned write response value, t…

### DIFF
--- a/index.js
+++ b/index.js
@@ -334,7 +334,7 @@ SengledLightAccessory.prototype.setPowerState = function(powerState, callback) {
 		return this.client.deviceSetOnOff(this.getId(), powerState);
 	}).then(() => {
 		this.context.status = powerState;
-		callback(null, powerState);
+		callback();
 	}).catch((err) => {
 		this.log("Failed to set power state to", powerState);
 		this.log(err);


### PR DESCRIPTION
Running homebridge -D, the following warning would appear:
Characteristic 'On': SET handler returned write response value, though the characteristic doesn't support write response.

This change removes the write response for the on set handler.